### PR TITLE
Add caret to dependencies (`fresh` and `setprototypeof`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "dependencies": {
     "accepts": "~1.3.7",
     "depd": "~1.1.2",
-    "fresh": "0.5.2",
+    "fresh": "^0.5.2",
     "parseurl": "~1.3.3",
     "proxy-addr": "~2.0.5",
     "range-parser": "~1.2.1",
-    "setprototypeof": "1.1.1",
+    "setprototypeof": "^1.1.1",
     "type-is": "~1.6.18"
   },
   "devDependencies": {


### PR DESCRIPTION
Add caret to dependencies following this discussion: [#290](https://github.com/expressjs/discussions/pull/290)